### PR TITLE
fix for assigning positive/negative labels during evaluation

### DIFF
--- a/ncxlib/neuralnetwork/neuralnet/nn.py
+++ b/ncxlib/neuralnetwork/neuralnet/nn.py
@@ -171,7 +171,7 @@ class NeuralNetwork:
         positive_class, negative_class = 1, 0
 
         # for +ve / -ve classes
-        if len(np.where(unique_targets >= 0)) != len(unique_targets):
+        if np.sum(unique_targets >= 0) != len(unique_targets):
             positive_class = unique_targets[unique_targets > 0][0]
             negative_class = unique_targets[unique_targets < 0][0]
         


### PR DESCRIPTION
`np.where(unique_targets >= 0)` returns a tuple: The length of `np.where(unique_targets >= 0) ` will always be 1 for a 1D array, as it is a tuple containing one array of indices. This condition will not behave as expected because len(np.where(...)) is not comparable to len(unique_targets) even when the targets are 0 and 1 only.